### PR TITLE
Ha sido añadida una solución provisional para la vulnerabilidad de se…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
         <dependency-check-maven.version>6.5.0</dependency-check-maven.version>
+
+        <!-- Interim work around for critical security vulnerability in log4j.  We should be able to remove the workaround -->
+        <!-- once Spring-Boot 2.6.2 is released. (https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot) -->
+        <log4j2.version>2.15.0</log4j2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
…guridad crítica en log4j.  Este parche podrá ser eliminado una vez que Spring-Boot 2.6.2 este disponible. (https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot)