### PR TITLE
Actualizaciones del reloj del Spectrum

### DIFF
--- a/src/main/java/machine/Spectrum.java
+++ b/src/main/java/machine/Spectrum.java
@@ -43,7 +43,7 @@ public class Spectrum extends z80core.MemIoOps implements Runnable, z80core.Noti
 
     private final Z80 z80;
     private final Memory memory;
-    private final Clock clock;
+    private final SpectrumClock clock;
     private final boolean[] contendedRamPage = new boolean[4];
     private final boolean[] contendedIOPage = new boolean[4];
     private int portFE, earBit = 0xbf, port7ffd, port1ffd, issueMask;
@@ -79,7 +79,7 @@ public class Spectrum extends z80core.MemIoOps implements Runnable, z80core.Noti
 
     public Spectrum(JSpeccySettings config) {
         super(0,0);
-        clock = Clock.getInstance();
+        clock = SpectrumClock.INSTANCE;
         settings = config;
         specSettings = settings.getSpectrumSettings();
         z80 = new Z80(this, this);

--- a/src/main/java/utilities/Microdrive.java
+++ b/src/main/java/utilities/Microdrive.java
@@ -7,7 +7,7 @@
  */
 package utilities;
 
-import machine.Clock;
+import machine.SpectrumClock;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -68,12 +68,12 @@ public class Microdrive {
     private boolean mdrFile;
 
     private File filename;
-    private final Clock clock;
+    private final SpectrumClock clock;
     private long startGap;
 
     public Microdrive() {
 
-        clock = Clock.getInstance();
+        clock = SpectrumClock.INSTANCE;
         isCartridge = mdrFile = false;
         writeProtected = true;
         cartridgePos = 0;

--- a/src/main/java/utilities/Tape.java
+++ b/src/main/java/utilities/Tape.java
@@ -23,7 +23,7 @@
 package utilities;
 
 import configuration.TapeSettingsType;
-import machine.Clock;
+import machine.SpectrumClock;
 import machine.MachineTypes;
 import machine.Memory;
 import z80core.Z80;
@@ -68,7 +68,7 @@ public class Tape implements machine.ClockTimeoutListener {
     private int bitTime;
     private byte byteTmp;
     private int cswPulses;
-    private final Clock clock;
+    private final SpectrumClock clock;
 
     public enum TapeState {
 
@@ -137,7 +137,7 @@ public class Tape implements machine.ClockTimeoutListener {
     public Tape(TapeSettingsType tapeSettings) {
         blockListeners = new ArrayList<>();
         stateListeners = new ArrayList<>();
-        clock = Clock.getInstance();
+        clock = SpectrumClock.INSTANCE;
         settings = tapeSettings;
         statePlay = State.STOP;
         tapePlaying = tapeRecording = false;

--- a/src/main/java/z80core/Z80.java
+++ b/src/main/java/z80core/Z80.java
@@ -227,7 +227,7 @@ package z80core;
 
 import jdk.internal.vm.annotation.Contended;
 import lombok.extern.slf4j.Slf4j;
-import machine.Clock;
+import machine.SpectrumClock;
 import snapshots.Z80State;
 
 import java.util.Arrays;
@@ -236,7 +236,7 @@ import java.util.BitSet;
 @Slf4j
 public class Z80 {
 
-    private final Clock clock;
+    private final SpectrumClock clock;
     private MemIoOps MemIoImpl;
     private NotifyOps NotifyImpl;
     // Se está ejecutando una instrucción DDxx, EDxx o FDxx 
@@ -395,7 +395,7 @@ public class Z80 {
 
     // Constructor de la clase
     public Z80(MemIoOps memory, NotifyOps notify) {
-        this.clock = Clock.getInstance();
+        this.clock = SpectrumClock.INSTANCE;
         MemIoImpl = memory;
         NotifyImpl = notify;
         execDone = false;


### PR DESCRIPTION
Le cambiamos el nombre a la clase re representa el reloj del ZX Spectrum para evitar ambigüedad con la propia clase de reloj en Java.
Actualizamos el código para implementar el singlenton del reloj de la forma recomendada a partir de Java 9 usando un enum