### PR TITLE
Some minor refactoring to allow better decoupling from the Swing UI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 
     <name>JSpeccy</name>
     <description>A multiplatform ZX Spectrum emulator written in Java</description>
-    <groupId>com.jsanchezv.jspeccy</groupId>
+    <groupId>uk.co.bithatch</groupId>
     <artifactId>jspeccy</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-bithatch</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -48,6 +48,9 @@
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <native-maven-plugin.version>0.10.6</native-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        
+        <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
     </properties>
 
     <dependencies>
@@ -223,9 +226,74 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                
+                 <configuration>
+                    <encoding>UTF-8</encoding>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <autoPublish>true</autoPublish>
+                    <waitForPublishCompletion>true</waitForPublishCompletion>
+                    <publishingServerId>ossrh-bithatch</publishingServerId>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
+            
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version> 
+                    <extensions>true</extensions>
+                </plugin>
+                
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.7</version>
+                </plugin>
+                
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
@@ -313,6 +381,12 @@
             </build>
         </profile>
     </profiles>
+    <developers>
+        <developer>
+            <id>brett</id>
+            <email>tanktarta@gmail.com</email>
+        </developer>
+    </developers>
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>A multiplatform ZX Spectrum emulator written in Java</description>
     <groupId>uk.co.bithatch</groupId>
     <artifactId>jspeccy</artifactId>
-    <version>1.0.2-bithatch</version>
+    <version>1.0.2-bithatch2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -260,7 +260,7 @@
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <configuration>
                     <autoPublish>true</autoPublish>
-                    <waitForPublishCompletion>true</waitForPublishCompletion>
+                    <waitUntil>published</waitUntil>
                     <publishingServerId>ossrh-bithatch</publishingServerId>
                 </configuration>
             </plugin>

--- a/src/main/java/gui/JSpeccy.java
+++ b/src/main/java/gui/JSpeccy.java
@@ -40,6 +40,10 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.plaf.basic.BasicFileChooserUI;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
 import configuration.JSpeccySettings;
 import jakarta.xml.bind.JAXB;
 import jakarta.xml.bind.JAXBContext;
@@ -52,9 +56,6 @@ import machine.Interface1DriveListener;
 import machine.Keyboard.JoystickModel;
 import machine.MachineTypes;
 import machine.Spectrum;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
 import snapshots.SnapshotException;
 import snapshots.SnapshotFactory;
 import snapshots.SnapshotFile;
@@ -559,8 +560,12 @@ public class JSpeccy extends javax.swing.JFrame {
         spectrum.setScreenComponent(jscr);
         jscr.setTvImage(spectrum.getTvImage());
         jscr.setBorderMode(settings.getSpectrumSettings().getBorderSize());
-        spectrum.setSpeedLabel(speedLabel);
-        tapeCatalog.setModel(tape.getTapeTableModel());
+        spectrum.onSpeedChange(speed -> {
+            SwingUtilities.invokeLater(() -> {
+                speedLabel.setText(String.format("%5d%%", speed));
+            });
+        });
+        tapeCatalog.setModel(new TapeTableModel(tape));
         tapeCatalog.getColumnModel().getColumn(0).setMaxWidth(150);
         lsm = tapeCatalog.getSelectionModel();
         lsm.addListSelectionListener((ListSelectionEvent event) -> {

--- a/src/main/java/gui/JSpeccy.java
+++ b/src/main/java/gui/JSpeccy.java
@@ -56,6 +56,7 @@ import machine.Interface1DriveListener;
 import machine.Keyboard.JoystickModel;
 import machine.MachineTypes;
 import machine.Spectrum;
+import machine.SpectrumClock;
 import snapshots.SnapshotException;
 import snapshots.SnapshotFactory;
 import snapshots.SnapshotFile;
@@ -554,7 +555,7 @@ public class JSpeccy extends javax.swing.JFrame {
 
         spectrum.loadConfigVars();
 
-        tape = new Tape(settings.getTapeSettings());
+        tape = new Tape(settings.getTapeSettings(), spectrum.getClock());
         spectrum.setTape(tape);
         jscr = new JSpeccyScreen();
         spectrum.setScreenComponent(jscr);

--- a/src/main/java/gui/JSpeccyScreen.java
+++ b/src/main/java/gui/JSpeccyScreen.java
@@ -8,7 +8,10 @@ package gui;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.RenderingHints;
+
+import machine.Screen;
 import machine.Spectrum;
 
 import java.awt.image.BufferedImage;
@@ -18,7 +21,7 @@ import java.awt.image.DataBufferInt;
  *
  * @author  jsanchez
  */
-public class JSpeccyScreen extends javax.swing.JComponent {
+public class JSpeccyScreen extends javax.swing.JComponent implements Screen {
 
     private BufferedImage tvImage;
     private BufferedImage tvImageFiltered;
@@ -194,6 +197,14 @@ public class JSpeccyScreen extends javax.swing.JComponent {
     }
 
     @Override
+	public void repaintScreen(Rectangle area) {
+    	if(area == null)
+    		repaint();
+    	else
+    		repaint(area);
+	}
+
+	@Override
     public void paintComponent(Graphics gc) {
         //super.paintComponent(gc);
         Graphics2D gc2 = (Graphics2D) gc;

--- a/src/main/java/gui/TapeTableModel.java
+++ b/src/main/java/gui/TapeTableModel.java
@@ -1,0 +1,63 @@
+package gui;
+
+import javax.swing.table.AbstractTableModel;
+
+import utilities.Tape;
+import utilities.TapeStateListener;
+import utilities.Tape.TapeState;
+
+@SuppressWarnings("serial")
+class TapeTableModel extends AbstractTableModel {
+
+        /**
+		 * 
+		 */
+		private final Tape tape;
+
+		public TapeTableModel(Tape tape) {
+			this.tape = tape;
+			tape.addTapeChangedListener(new TapeStateListener() {
+				
+				@Override
+				public void stateChanged(TapeState state) {
+					if(state == TapeState.INSERT || state == TapeState.EJECT) {
+						fireTableDataChanged();	
+					}
+				}
+			});
+        }
+
+        @Override
+        public int getRowCount() {
+            return this.tape.getNumBlocks();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return 3;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+
+//            log.trace("getValueAt row {}, col {}", row, col);
+            return switch (col) {
+                case 0 -> String.format("%4d", row + 1);
+                case 1 -> this.tape.getBlockType(row);
+                case 2 -> this.tape.getBlockInfo(row);
+                default -> "NON EXISTENT COLUMN!";
+            };
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("gui/Bundle"); // NOI18N
+
+            return switch (col) {
+                case 0 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title0");
+                case 1 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title1");
+                case 2 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title2");
+                default -> "COLUMN ERROR!";
+            };
+        }
+    }

--- a/src/main/java/machine/Interface1.java
+++ b/src/main/java/machine/Interface1.java
@@ -46,7 +46,7 @@ public class Interface1 {
 
     private final ArrayList<Interface1DriveListener> driveListeners = new ArrayList<>();
 
-    public Interface1(Interface1Type if1settings) {
+    public Interface1(Interface1Type if1settings, SpectrumClock clock) {
         settings = if1settings;
         mdrFlipFlop = 0;
         mdrSelected = 0;
@@ -54,7 +54,7 @@ public class Interface1 {
 
         microdrive = new Microdrive[8];
         for (int mdr = 0; mdr < 8; mdr++)
-            microdrive[mdr] = new Microdrive();
+            microdrive[mdr] = new Microdrive(clock);
 
         commsClk = false;
         lan = 0;

--- a/src/main/java/machine/Screen.java
+++ b/src/main/java/machine/Screen.java
@@ -1,0 +1,14 @@
+package machine;
+
+import java.awt.Rectangle;
+
+public interface Screen {
+
+	void repaintScreen(Rectangle area);
+
+	int getZoom();
+
+	default void borderUpdated(int border) {
+	}
+
+}

--- a/src/main/java/machine/Spectrum.java
+++ b/src/main/java/machine/Spectrum.java
@@ -80,10 +80,10 @@ public class Spectrum extends z80core.MemIoOps implements Runnable, z80core.Noti
 
     public Spectrum(JSpeccySettings config) {
         super(0,0);
-        clock = SpectrumClock.INSTANCE;
+        clock = new SpectrumClock();
         settings = config;
         specSettings = settings.getSpectrumSettings();
-        z80 = new Z80(this, this);
+        z80 = new Z80(this, this, clock);
         memory = new Memory(settings);
         initGFX();
         speedometer = 0;
@@ -96,7 +96,7 @@ public class Spectrum extends z80core.MemIoOps implements Runnable, z80core.Noti
         isSoundEnabled = false;
         paused = true;
         borderMode = 1;
-        if1 = new Interface1(settings.getInterface1Settings());
+        if1 = new Interface1(settings.getInterface1Settings(), clock);
 
         if (System.getProperty("os.name").contains("Linux")) {
             try {
@@ -1961,6 +1961,10 @@ public class Spectrum extends z80core.MemIoOps implements Runnable, z80core.Noti
     public BufferedImage getTvImage() {
         return tvImage;
     }
+
+	public SpectrumClock getClock() {
+		return clock;
+	}
 
     public void setBorderMode(int mode) {
         if (borderMode == mode) {

--- a/src/main/java/machine/SpectrumClock.java
+++ b/src/main/java/machine/SpectrumClock.java
@@ -19,9 +19,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 @Slf4j
 @ToString(onlyExplicitlyIncluded = true, includeFieldNames = true)
-public enum SpectrumClock {
-
-    INSTANCE;
+public class SpectrumClock {
 
     @Getter
     @ToString.Include

--- a/src/main/java/utilities/Microdrive.java
+++ b/src/main/java/utilities/Microdrive.java
@@ -71,9 +71,9 @@ public class Microdrive {
     private final SpectrumClock clock;
     private long startGap;
 
-    public Microdrive() {
+    public Microdrive(SpectrumClock clock) {
 
-        clock = SpectrumClock.INSTANCE;
+        this.clock = clock;
         isCartridge = mdrFile = false;
         writeProtected = true;
         cartridgePos = 0;

--- a/src/main/java/utilities/Tape.java
+++ b/src/main/java/utilities/Tape.java
@@ -22,13 +22,6 @@
  */
 package utilities;
 
-import configuration.TapeSettingsType;
-import machine.SpectrumClock;
-import machine.MachineTypes;
-import machine.Memory;
-import z80core.Z80;
-
-import javax.swing.table.AbstractTableModel;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -44,7 +37,13 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
+
+import configuration.TapeSettingsType;
 import lombok.extern.slf4j.Slf4j;
+import machine.MachineTypes;
+import machine.Memory;
+import machine.SpectrumClock;
+import z80core.Z80;
 
 /**
  *
@@ -126,7 +125,6 @@ public class Tape implements machine.ClockTimeoutListener {
     private int freqSample;
     private float cswStatesSample;
     private MachineTypes spectrumModel;
-    private final TapeTableModel tapeTableModel;
     private final TapeSettingsType settings;
     // # of Calls & origin block of TZX CALL block 
     private int nCalls, callBlk;
@@ -152,7 +150,6 @@ public class Tape implements machine.ClockTimeoutListener {
         nOffsetBlocks = 0;
         idxHeader = 0;
         Arrays.fill(offsetBlocks, 0);
-        tapeTableModel = new TapeTableModel();
     }
 
     /**
@@ -244,7 +241,7 @@ public class Tape implements machine.ClockTimeoutListener {
         cpu = z80;
     }
 
-    private int getNumBlocks() {
+    public int getNumBlocks() {
         return tapeExtension == TapeExtensionType.NO_TAPE ? 1 : nOffsetBlocks + 1;
     }
 
@@ -276,7 +273,7 @@ public class Tape implements machine.ClockTimeoutListener {
         return new String(msg);
     }
 
-    private String getBlockType(int block) {
+    public String getBlockType(int block) {
         java.util.ResourceBundle bundle =
                 java.util.ResourceBundle.getBundle("utilities/Bundle"); // NOI18N
         if (tapeExtension == TapeExtensionType.NO_TAPE) {
@@ -354,7 +351,7 @@ public class Tape implements machine.ClockTimeoutListener {
         };
     }
 
-    private String getBlockInfo(int block) {
+    public String getBlockInfo(int block) {
         java.util.ResourceBundle bundle =
                 java.util.ResourceBundle.getBundle("utilities/Bundle"); // NOI18N
 
@@ -544,10 +541,6 @@ public class Tape implements machine.ClockTimeoutListener {
         return msg;
     }
 
-    public TapeTableModel getTapeTableModel() {
-        return tapeTableModel;
-    }
-
     @Override
     public void clockTimeout() {
 
@@ -623,7 +616,6 @@ public class Tape implements machine.ClockTimeoutListener {
                 return false;
         }
 
-        tapeTableModel.fireTableDataChanged();
         fireTapeStateChanged(TapeState.INSERT);
         fireTapeBlockChanged(0);
         return true;
@@ -663,7 +655,6 @@ public class Tape implements machine.ClockTimeoutListener {
                 return false;
         }
 
-        tapeTableModel.fireTableDataChanged();
         fireTapeStateChanged(TapeState.INSERT);
         fireTapeBlockChanged(selectedBlock);
         return true;
@@ -678,7 +669,6 @@ public class Tape implements machine.ClockTimeoutListener {
         tapeBuffer = null;
         filename = null;
         nOffsetBlocks = 0;
-        tapeTableModel.fireTableDataChanged();
         fireTapeStateChanged(TapeState.EJECT);
         return true;
     }
@@ -727,8 +717,8 @@ public class Tape implements machine.ClockTimeoutListener {
         manualMode = origin;
         statePlay = State.START;
 
-        fireTapeStateChanged(TapeState.PLAY);
         tapePlaying = true;
+        fireTapeStateChanged(TapeState.PLAY);
         clock.addClockTimeoutListener(this);
         clockTimeout();
         return true;
@@ -1949,45 +1939,5 @@ public class Tape implements machine.ClockTimeoutListener {
 
         timeLastOut = clock.getAbsTstates();
         micBit = micState;
-    }
-
-    private class TapeTableModel extends AbstractTableModel {
-
-        public TapeTableModel() {
-        }
-
-        @Override
-        public int getRowCount() {
-            return getNumBlocks();
-        }
-
-        @Override
-        public int getColumnCount() {
-            return 3;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-
-//            log.trace("getValueAt row {}, col {}", row, col);
-            return switch (col) {
-                case 0 -> String.format("%4d", row + 1);
-                case 1 -> getBlockType(row);
-                case 2 -> getBlockInfo(row);
-                default -> "NON EXISTENT COLUMN!";
-            };
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("gui/Bundle"); // NOI18N
-
-            return switch (col) {
-                case 0 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title0");
-                case 1 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title1");
-                case 2 -> bundle.getString("JSpeccy.tapeCatalog.columnModel.title2");
-                default -> "COLUMN ERROR!";
-            };
-        }
     }
 }

--- a/src/main/java/utilities/Tape.java
+++ b/src/main/java/utilities/Tape.java
@@ -136,10 +136,10 @@ public class Tape implements machine.ClockTimeoutListener {
     private static final String tzxCreator = "TZX created with JSpeccy v0.95";
     private boolean manualMode = false;
 
-    public Tape(TapeSettingsType tapeSettings) {
+    public Tape(TapeSettingsType tapeSettings, SpectrumClock clock) {
         blockListeners = new ArrayList<>();
         stateListeners = new ArrayList<>();
-        clock = SpectrumClock.INSTANCE;
+        this.clock = clock;
         settings = tapeSettings;
         statePlay = State.STOP;
         tapePlaying = tapeRecording = false;

--- a/src/main/java/z80core/Z80.java
+++ b/src/main/java/z80core/Z80.java
@@ -412,8 +412,8 @@ public class Z80 {
     private final BitSet breakpointAt = new BitSet(65536);
 
     // Constructor de la clase
-    public Z80(MemIoOps memory, NotifyOps notify) {
-        this.clock = SpectrumClock.INSTANCE;
+    public Z80(MemIoOps memory, NotifyOps notify, SpectrumClock clock) {
+        this.clock = clock;
         MemIoImpl = memory;
         NotifyImpl = notify;
         execDone = false;


### PR DESCRIPTION
I am using JSpeccy in an Eclipse based IDE I am building, for the ZX Spectrum and ZX Spectrum Next, as it was very nearly a perfect fit for what I needed :)  . This PR contains the changes that were required to to get a good level of integration with the Eclipse framework and SWT, and are mainly about decoupling further from the Swing UI.  So the only part where Swing is still used is the renderer of the screen  itself. Frankly this is a good thing, Swing and its `BufferedImage` are waaaay  better than SWTs `ImageData`.  Screenshot of JSpeccy inside the IDE here if you are interested .. https://github.com/bithatch/eclipzx/blob/main/src/web/screenshot-emulator.png

 * Made `Spectrum` implement `Closeable` (hide `IOException` on close). This stops the emulation thread instead of just pausing it.
 * Made tape functionality accessible outside of the user interface (i.e. more `public`).
 * Introduced lightweight `Screen` interface that by default `JSpeccyScreen` implements, allowing alternative implementations to be plugged in. `setScreenComponent` now accepts a `Screen` instead of `JSpeccyScreen`.
 * Added hook to be notified of border colour changes.
 * Changed `setSpeedLabel(JLabel speed)` to accept a `Consumer<Long>` instead, decoupling from Swing.